### PR TITLE
Fix cargo deny config.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,21 +1,19 @@
 [licenses]
-unlicensed = "deny"
-
 #
 # License types that we explicitly allow
 #
-
 allow = [
-    "Apache-2.0",
-    "BSD-2-Clause",
-    "BSD-2-Clause-FreeBSD",
-    "BSD-3-Clause",
-    "BSL-1.0",
-    "ISC",
-    "MIT",
-    "Unlicense",
-    "Zlib",
-    "MPL-2.0",
-    "CC0-1.0",
-    "OpenSSL",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-2-Clause-FreeBSD",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "ISC",
+  "MIT",
+  "Unlicense",
+  "Zlib",
+  "MPL-2.0",
+  "CC0-1.0",
+  "OpenSSL",
 ]
+


### PR DESCRIPTION
It now denies all unlicensed dependency crates.